### PR TITLE
agbot snap

### DIFF
--- a/distribution/scripts/anax/anax.sh
+++ b/distribution/scripts/anax/anax.sh
@@ -9,6 +9,19 @@ if ! [ -e "$SNAP_COMMON"/workload_ro ]; then
   mkdir -p "$SNAP_COMMON"/workload_ro
 fi
 
+if ! [ -e "$SNAP_COMMON"/policy.d ]; then
+  mkdir -p "$SNAP_COMMON"/policy.d
+fi
+
+# setup agbot specific directories
+if ! [ -e "$SNAP_COMMON"/agbot ]; then
+  mkdir -p "$SNAP_COMMON"/agbot
+fi
+
+if ! [ -e "$SNAP_COMMON"/agbot/policy.d ]; then
+  mkdir -p "$SNAP_COMMON"/agbot/policy.d
+fi
+
 if ! [ "$(ls -A $SNAP_DATA/)" ]; then
   cp -Rfap "$SNAP/seed/data/." $SNAP_DATA/
 
@@ -36,6 +49,10 @@ export CMTN_WHISPER_ADDRESS_PATH=${CMTN_WHISPER_ADDRESS_PATH:=$SNAP_COMMON/eth/s
 export mtn_soliditycontract_block_read_delay=${mtn_soliditycontract_block_read_delay:=3}
 
 export CMTN_DIRECTORY_VERSION=${CMTN_DIRECTORY_VERSION:=$(cat $(sourceOverrideOrDefaultPath "horizon_directory_version"))}
+
+export CMTN_EXCHANGE_URL=${CMTN_EXCHANGE_URL:=$(cat $(sourceOverrideOrDefaultPath "horizon_exchange_url"))}
+
+export CMTN_DATA_VERIFICATION_URL=${CMTN_DATA_VERIFICATION_URL:=$(cat $(sourceOverrideOrDefaultPath "horizon_data_verification_url"))}
 
 export CMTN_DEVICE_ID=${CMTN_DEVICE_ID:=$(cat $SNAP_COMMON/config/device_id)}
 

--- a/distribution/seed/data/anax/default-anax.json.tmpl
+++ b/distribution/seed/data/anax/default-anax.json.tmpl
@@ -1,13 +1,32 @@
 {
-  "TorrentDir": "${SNAP_COMMON}/torrent",
-  "APIListen": "0.0.0.0:80",
-  "DBPath": "${SNAP_COMMON}/",
-  "GethURL": "http://127.0.0.1:8545",
-  "DockerEndpoint": "unix:///var/run/docker.sock",
-  "StaticWebContent": "${SNAP}/srv/static",
-  "PublicKeyPath": "${SNAP_DATA}/anax/mtn-publicKey.pem",
-  "CACertsPath": "${SNAP_DATA}/anax/horizon.pem",
-  "MicropaymentEnforced": true,
-  "DefaultCPUSet": "${HORIZON_WORKLOAD_CPUSET}",
-  "WorkloadROStorage": "${SNAP_COMMON}/workload_ro"
+  "Edge": {
+    "TorrentDir": "${SNAP_COMMON}/torrent",
+    "APIListen": "0.0.0.0:80",
+    "DBPath": "${SNAP_COMMON}/",
+    "GethURL": "http://127.0.0.1:8545",
+    "DockerEndpoint": "unix:///var/run/docker.sock",
+    "StaticWebContent": "${SNAP}/srv/static",
+    "PublicKeyPath": "${SNAP_DATA}/anax/mtn-publicKey.pem",
+    "CACertsPath": "${SNAP_DATA}/anax/horizon.pem",
+    "DefaultCPUSet": "${HORIZON_WORKLOAD_CPUSET}",
+    "WorkloadROStorage": "${SNAP_COMMON}/workload_ro",
+    "ExchangeURL": "${CMTN_EXCHANGE_URL}",
+    "PolicyPath": "${SNAP_COMMON}/policy.d/",
+    "ExchangeHeartbeat": 60,
+    "AgreementTimeoutS": 180
+  },
+  "AgreementBot": {
+    "DBPath": "${SNAP_COMMON}/agbot/",
+    "GethURL": "http://127.0.0.1:8545",
+    "TxLostDelayTolerationSeconds": 240,
+    "AgreementWorkers": 5,
+    "AgreementTimeoutS": 180,
+    "PolicyPath": "${SNAP_COMMON}/agbot/policy.d/",
+    "NewContractIntervalS": 15,
+    "ProcessGovernanceIntervalS": 10,
+    "IgnoreContractWithAttribs": "ethereum_account",
+    "ExchangeURL": "${CMTN_EXCHANGE_URL}",
+    "ExchangeHeartbeat": 60,
+    "ActiveDeviceTimeoutS": 180
+  }
 }

--- a/distribution/seed/data/anax/default-horizon_data_verification_url
+++ b/distribution/seed/data/anax/default-horizon_data_verification_url
@@ -1,0 +1,1 @@
+https://bluehorizon.network/agheartbeatapi/all.json

--- a/distribution/seed/data/anax/default-horizon_exchange_url
+++ b/distribution/seed/data/anax/default-horizon_exchange_url
@@ -1,0 +1,1 @@
+https://exchange.bluehorizon.network/api/v1/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bluehorizon
-version: 1.6.17
+version: 2.0.0
 summary: Horizon Decentralized Autonomous Edge Compute System...
 description: This snap includes all Horizon system control components...
 confinement: devmode
@@ -49,8 +49,6 @@ parts:
       - gettext
       - jq
     source: https://github.com/open-horizon/anax.git
-    source-branch: version/1
-
 
   ethereum:
     plugin: make


### PR DESCRIPTION
Note: The changes to anax.json.tmpl are for a devmode agbot, not an agbot in the cloud. The config for an agbot in the cloud has more things configured. There is a sample of a cloud agbot snap config in the anax project under the agreementbot/devops directory.